### PR TITLE
fix: Clear cache button does not correctly clear cache

### DIFF
--- a/Assets/Prefabs/Lobby Prefab.prefab
+++ b/Assets/Prefabs/Lobby Prefab.prefab
@@ -44,7 +44,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 975b42b4ff0287b46a8d0af561a11525, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shouldClear: 0
 --- !u!1 &1480175469755085032
 GameObject:
   m_ObjectHideFlags: 0
@@ -1762,6 +1761,30 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5557438383625807458, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991309132250673583, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991309132250673583, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991309132250673583, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991309132250673583, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991309132250673583, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5991309132250673583, guid: 93f657c83e35b774cb10a62f8b03c8a9, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/Menu/GameMenu.prefab
+++ b/Assets/Prefabs/Menu/GameMenu.prefab
@@ -3998,7 +3998,7 @@ MonoBehaviour:
       - m_Target: {fileID: 7270956532408635033}
         m_TargetAssemblyTypeName: CollabXR.Development.ClearCache, Assembly-CSharp
         m_MethodName: DebugClearCache
-        m_Mode: 1
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Prefabs/Menu/MenuMenu.prefab
+++ b/Assets/Prefabs/Menu/MenuMenu.prefab
@@ -1392,14 +1392,14 @@ MonoBehaviour:
       - m_Target: {fileID: 2594107584948518577}
         m_TargetAssemblyTypeName: CollabXR.Development.ClearCache, Assembly-CSharp
         m_MethodName: DebugClearCache
-        m_Mode: 1
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
-          m_BoolArgument: 0
+          m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &5277576191077949564
 MonoBehaviour:

--- a/Assets/Prefabs/Session Prefab.prefab
+++ b/Assets/Prefabs/Session Prefab.prefab
@@ -404,7 +404,7 @@ RectTransform:
   - {fileID: 3068495898953645338}
   - {fileID: 4106143730032982485}
   - {fileID: 2285804238025390766}
-  m_Father: {fileID: 6987322051992426390}
+  m_Father: {fileID: 2714622493693967927}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1054,6 +1054,78 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 70819211554452420, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 70819211554452420, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 70819211554452420, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 70819211554452420, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 70819211554452420, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 70819211554452420, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 89591218511368803, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 89591218511368803, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 89591218511368803, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 89591218511368803, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 89591218511368803, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 89591218511368803, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 115246356723248323, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 115246356723248323, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 115246356723248323, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 115246356723248323, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 115246356723248323, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 115246356723248323, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 172125122545007105, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1106,6 +1178,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 415730355718436818, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 415730355718436818, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 522095897552833735, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1123,6 +1203,30 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 522095897552833735, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 626360444822490515, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 626360444822490515, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 626360444822490515, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 626360444822490515, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 626360444822490515, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 626360444822490515, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1134,6 +1238,98 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 760810985709632950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 760810985709632950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 760810985709632950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 760810985709632950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 760810985709632950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 760810985709632950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 930315141826418687, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 930315141826418687, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 930315141826418687, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 930315141826418687, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 930315141826418687, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 959376258319163816, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 959376258319163816, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 959376258319163816, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 959376258319163816, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 959376258319163816, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 959376258319163816, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022039523651251551, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022039523651251551, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022039523651251551, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022039523651251551, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022039523651251551, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022039523651251551, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1047823764492298628, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1151,6 +1347,22 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1047823764492298628, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156122936233842030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156122936233842030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156122936233842030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156122936233842030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1178,6 +1390,62 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 66995b6b61aed864daa956ae255d7fee, type: 3}
+    - target: {fileID: 1234315797375813599, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1234315797375813599, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235592676293365379, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235592676293365379, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235592676293365379, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235592676293365379, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235592676293365379, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235592676293365379, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1331593321201224537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1331593321201224537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1331593321201224537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1331593321201224537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1331593321201224537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1331593321201224537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1602588057408548969, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1274,6 +1542,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2117442301618015753, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2117442301618015753, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2117442301618015753, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2117442301618015753, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2117442301618015753, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2117442301618015753, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2133554258190821011, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -1318,6 +1610,26 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2448360380329657359, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2448360380329657359, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2448360380329657359, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2448360380329657359, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2448360380329657359, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2558627036748340484, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -1343,6 +1655,30 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2572642415911861068, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574323605664766569, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574323605664766569, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574323605664766569, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574323605664766569, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574323605664766569, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574323605664766569, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1382,12 +1718,52 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2957335343506143139, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2957335343506143139, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2957335343506143139, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2957335343506143139, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3013535608929211881, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3013535608929211881, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3027988636245992030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3027988636245992030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3027988636245992030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3027988636245992030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3027988636245992030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3027988636245992030, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3081023551249309549, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -1459,6 +1835,26 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3197711590374041157, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313528080869087456, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313528080869087456, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313528080869087456, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313528080869087456, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313528080869087456, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1466,6 +1862,10 @@ PrefabInstance:
       propertyPath: m_Value
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3423586123428543701, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3449714462036262736, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1571,6 +1971,30 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3692310084754432499, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3778270997509700539, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3778270997509700539, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3778270997509700539, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3778270997509700539, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3778270997509700539, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3778270997509700539, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1634,6 +2058,66 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4186150214198233252, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4186150214198233252, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4186150214198233252, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4186150214198233252, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4195220763943729132, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4195220763943729132, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4195220763943729132, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4195220763943729132, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4195220763943729132, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4195220763943729132, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4226519983321169073, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4226519983321169073, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4226519983321169073, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4226519983321169073, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4226519983321169073, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4300399642826458182, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1647,6 +2131,78 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4300399642826458182, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4323431913100130507, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4323431913100130507, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4323431913100130507, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4323431913100130507, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4323431913100130507, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4323431913100130507, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4349169097668392068, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4349169097668392068, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4349169097668392068, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4349169097668392068, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4423296571823206537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4423296571823206537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4423296571823206537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4423296571823206537, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560002693464648308, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560002693464648308, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560002693464648308, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4560002693464648308, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1711,6 +2267,22 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4706633742192272482, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4789022099081424443, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4789022099081424443, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4789022099081424443, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4789022099081424443, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -1786,6 +2358,30 @@ PrefabInstance:
       propertyPath: rightHandToolIcon
       value: 
       objectReference: {fileID: 2426859938693044831}
+    - target: {fileID: 5072494020376467438, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072494020376467438, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072494020376467438, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072494020376467438, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072494020376467438, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072494020376467438, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5076134714736433827, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1914,6 +2510,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5382962934113982646, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5382962934113982646, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5382962934113982646, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5382962934113982646, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5382962934113982646, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5382962934113982646, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5521735882419539059, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1936,6 +2556,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5521735882419539059, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5695008025107703409, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5704265588755987960, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -2030,6 +2654,94 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5972189416431122093, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5972189416431122093, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5972189416431122093, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5972189416431122093, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5972189416431122093, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5972189416431122093, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6152049090202157349, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6152049090202157349, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6152049090202157349, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6152049090202157349, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6152049090202157349, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6350139930130362904, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6350139930130362904, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6350139930130362904, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6351264520983105673, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6351264520983105673, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6351264520983105673, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6351264520983105673, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6361579227171505913, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6361579227171505913, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6361579227171505913, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6361579227171505913, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6380209694278787286, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2051,6 +2763,46 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6380209694278787286, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381163296961460722, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381163296961460722, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381163296961460722, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381163296961460722, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381163296961460722, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381163296961460722, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6457625929755579182, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6457625929755579182, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6457625929755579182, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6457625929755579182, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -2100,6 +2852,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6501324020257958855, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512153122078120282, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512153122078120282, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512153122078120282, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512153122078120282, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512153122078120282, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512153122078120282, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586400217048905162, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586400217048905162, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586400217048905162, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586400217048905162, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586400217048905162, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586400217048905162, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6624065542074898044, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6685700629175130543, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -2252,6 +3056,62 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7012753622601731590, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019736979902637031, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019736979902637031, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019736979902637031, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019736979902637031, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019736979902637031, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019736979902637031, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7022902049464280406, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7022902049464280406, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7022902049464280406, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7022902049464280406, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7022902049464280406, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174185794878697598, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174185794878697598, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174185794878697598, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7226229982694885589, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -2334,6 +3194,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7334799453542309197, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334799453542309197, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334799453542309197, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334799453542309197, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334799453542309197, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7334799453542309197, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7347153818917618375, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2406,6 +3290,54 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7543317838878842376, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7543317838878842376, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7543317838878842376, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7543317838878842376, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7543317838878842376, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7543317838878842376, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578711838929777079, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578711838929777079, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578711838929777079, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578711838929777079, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578711838929777079, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578711838929777079, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7614317763172053706, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -2416,6 +3348,30 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7614317763172053706, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7773193885116890937, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7773193885116890937, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7773193885116890937, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7773193885116890937, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7773193885116890937, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7773193885116890937, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7875316248323781893, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -2451,6 +3407,30 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8022214564083517382, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064621609982075168, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064621609982075168, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064621609982075168, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064621609982075168, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064621609982075168, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064621609982075168, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -2522,6 +3502,58 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8383539603182409532, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8383539603182409532, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8383539603182409532, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8383539603182409532, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8383539603182409532, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8389893357025567970, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8389893357025567970, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8468366836358967517, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8468366836358967517, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8468366836358967517, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8468366836358967517, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8468366836358967517, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8468366836358967517, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8547897500020364307, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2536,15 +3568,91 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8547897500020364307, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8604690981019271283, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8604690981019271283, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8604690981019271283, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8645691539785348167, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8752496696134444902, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8752496696134444902, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8752496696134444902, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8752496696134444902, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8764331683371253826, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8764331683371253826, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8764331683371253826, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8764331683371253826, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8764331683371253826, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8764331683371253826, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8884366664963134755, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917216232766669707, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917216232766669707, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917216232766669707, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917216232766669707, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917216232766669707, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917216232766669707, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8926566634359557950, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_IsActive
@@ -2580,6 +3688,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8990250060022183044, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
       propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9079810837467026704, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9079810837467026704, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9079810837467026704, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9079810837467026704, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9166720468990590368, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -2646,8 +3770,8 @@ PrefabInstance:
     m_RemovedGameObjects:
     - {fileID: 3408858201276862039, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
     m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 2311372694744578214, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
-      insertIndex: 0
+    - targetCorrespondingSourceObject: {fileID: 7298109157325099271, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
+      insertIndex: -1
       addedObject: {fileID: 6441038060720275952}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
@@ -2665,11 +3789,6 @@ MonoBehaviour:
 --- !u!4 &2714622493693967927 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7298109157325099271, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
-  m_PrefabInstance: {fileID: 4675951764225830704}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &6987322051992426390 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2311372694744578214, guid: 4e754e3d3536a254cb9675eb52b222d8, type: 3}
   m_PrefabInstance: {fileID: 4675951764225830704}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4857978393793527924

--- a/Assets/Scripts/Development/ClearCache.cs
+++ b/Assets/Scripts/Development/ClearCache.cs
@@ -8,8 +8,8 @@ namespace CollabXR.Development
 	{
 		public void DebugClearCache()
 		{
-			Caching.ClearCache();
-			Debug.Log("Clearing cache");
+			AssetBundle.UnloadAllAssetBundles(true);
+			Debug.Log($"Attempting to clear cache, result: {Caching.ClearCache()}");
 		}
 	}
 }

--- a/Assets/Scripts/Development/ClearCache.cs
+++ b/Assets/Scripts/Development/ClearCache.cs
@@ -1,14 +1,13 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace CollabXR.Development
 {
 	public class ClearCache : MonoBehaviour
 	{
-		public void DebugClearCache()
+		// Toggled false while in room, will break object loading otherwise.
+		public void DebugClearCache(bool unloadAllObjects)
 		{
-			AssetBundle.UnloadAllAssetBundles(true);
+			AssetBundle.UnloadAllAssetBundles(unloadAllObjects);
 			Debug.Log($"Attempting to clear cache, result: {Caching.ClearCache()}");
 		}
 	}


### PR DESCRIPTION
1. Clearing cache without first unloading asset bundles will always return false.

2. Repeated use of clear cache after leaving a room with loaded assets will freeze the Quest 3 headset and force a restart.

These issues seem to be resolved after adding a unload call before clearing cache.