### PR TITLE
Fixed animation playback does not play on awake

### DIFF
--- a/Assets/Scripts/Playback/NetworkPlaybackDirector.cs
+++ b/Assets/Scripts/Playback/NetworkPlaybackDirector.cs
@@ -40,16 +40,18 @@ namespace CollabXR.Cycles
 				return;
 			}
 
+			SubscribeToViewModel();
+
 			_director = GetComponentInChildren<PlaybackDirector>();
 			if (_director != null)
 			{
 				_director.SetNetworkDriven(!HasStateAuthority);
 
 				if (_director.PlayOnAwake && HasStateAuthority)
+				{
 					_viewModel.RequestPlay();
+				}
 			}
-
-			SubscribeToViewModel();
 		}
 
 		private void SubscribeToViewModel()


### PR DESCRIPTION
Resolves #17 

Script attempts to play animation before the proper delegates are subscribed. Confirmed now that playback and toggles spawn correctly on simulator and headset.