### PR TITLE
fix: cesium menu overlap with others

### DIFF
--- a/Assets/Prefabs/Context Menus/Cesium/Cesium Map Context.prefab
+++ b/Assets/Prefabs/Context Menus/Cesium/Cesium Map Context.prefab
@@ -3923,8 +3923,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5111291335119680800
 MonoBehaviour:

--- a/Assets/Prefabs/Context Menus/Cesium/Cesium Mariana Trench Context.prefab
+++ b/Assets/Prefabs/Context Menus/Cesium/Cesium Mariana Trench Context.prefab
@@ -2883,8 +2883,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5111291335119680800
 MonoBehaviour:

--- a/Assets/Prefabs/Context Menus/Cesium/Cesium Mars Context.prefab
+++ b/Assets/Prefabs/Context Menus/Cesium/Cesium Mars Context.prefab
@@ -2889,8 +2889,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5111291335119680800
 MonoBehaviour:

--- a/Assets/Prefabs/Context Menus/Cesium/Cesium Moon Context.prefab
+++ b/Assets/Prefabs/Context Menus/Cesium/Cesium Moon Context.prefab
@@ -2892,8 +2892,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5111291335119680800
 MonoBehaviour:

--- a/Assets/Prefabs/Context Menus/Star Catalog/Star Catalog Context.prefab
+++ b/Assets/Prefabs/Context Menus/Star Catalog/Star Catalog Context.prefab
@@ -49,6 +49,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10de15684cb9a6a4da2eeeba2dbdb5e2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  menuIcon: {fileID: 0}
   magnitudeSlider: {fileID: 3598681704647220978}
   latitudeSlider: {fileID: 7128126392886163988}
   longitudeSlider: {fileID: 5602941982748895161}
@@ -98,8 +99,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5111291335119680800
 MonoBehaviour:
@@ -230,6 +231,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -366,6 +368,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -502,6 +505,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -638,6 +642,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0

--- a/Assets/Prefabs/Context Menus/VirtualCameraContext.prefab
+++ b/Assets/Prefabs/Context Menus/VirtualCameraContext.prefab
@@ -228,8 +228,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5111291335119680800
 MonoBehaviour:

--- a/Assets/Scripts/Playback/PlaybackContextProvider.cs
+++ b/Assets/Scripts/Playback/PlaybackContextProvider.cs
@@ -48,5 +48,7 @@ namespace CollabXR
 		}
 
 		public GameObject GetContextPrefab() => contextPrefab;
+
+		public GameObject SelfObject => gameObject;
 	}
 }

--- a/Assets/Scripts/UI/Context/CollabContextMenu.cs
+++ b/Assets/Scripts/UI/Context/CollabContextMenu.cs
@@ -30,6 +30,8 @@ namespace CollabXR.UI
 
 		public Action OnRequestAuthority = delegate { };
 
+		private CollabObject currentObject;
+
 		PlayerRef lastAuthority = PlayerRef.None;
 
 		private void SafeGiveContext(CollabContext context, CollabObject obj)
@@ -47,6 +49,8 @@ namespace CollabXR.UI
 
 		public void OpenContext(CollabObject obj)
 		{
+			currentObject = obj;
+
 			// Clean up existing tabs and deactivate them
 			foreach (var context in contextTabs.Values)
 			{
@@ -230,6 +234,11 @@ namespace CollabXR.UI
 			if (activeTab != null)
 			{
 				activeTab.OnStateAuthorityChanged();
+			}
+
+			if (currentObject != null)
+			{
+				OpenContext(currentObject);
 			}
 		}
 

--- a/Assets/Scripts/UI/Context/CollabContextMenu.cs
+++ b/Assets/Scripts/UI/Context/CollabContextMenu.cs
@@ -171,7 +171,7 @@ namespace CollabXR.UI
 
 		private void DiscoverAndAddRegisteredContexts(CollabObject obj)
 		{
-			var providers = obj.GetComponents<IContextProvider>();
+			var providers = obj.GetComponentsInChildren<IContextProvider>(true);
 
 			foreach (var provider in providers)
 			{
@@ -180,7 +180,7 @@ namespace CollabXR.UI
 					continue;
 				}
 
-				if (provider.SelfObject.TryGetComponent(out BrushSubStroke b))
+				if (provider.SelfObject.transform.Cast<Transform>().Any(c => c.TryGetComponent(out BrushSubStroke b)))
 				{
 					continue;
 				}

--- a/Assets/Scripts/UI/Context/CollabContextMenu.cs
+++ b/Assets/Scripts/UI/Context/CollabContextMenu.cs
@@ -5,6 +5,7 @@ using CollabXR.Cycles;
 using CollabXR.ModExtras;
 using CollabXR.Networking;
 using CollabXR.Objects;
+using CollabXR.Tools.Drawing;
 using CollabXR.Tools.Palette;
 using CollabXR.UI;
 using Fusion;
@@ -174,7 +175,7 @@ namespace CollabXR.UI
 
 			foreach (var provider in providers)
 			{
-				if (provider == null)
+				if (provider == null || provider.SelfObject.GetComponentInChildren<BrushSubStroke>() != null)
 				{
 					continue;
 				}

--- a/Assets/Scripts/UI/Context/CollabContextMenu.cs
+++ b/Assets/Scripts/UI/Context/CollabContextMenu.cs
@@ -171,11 +171,16 @@ namespace CollabXR.UI
 
 		private void DiscoverAndAddRegisteredContexts(CollabObject obj)
 		{
-			var providers = obj.GetComponentsInChildren<IContextProvider>(true);
+			var providers = obj.GetComponents<IContextProvider>();
 
 			foreach (var provider in providers)
 			{
-				if (provider == null || provider.SelfObject.GetComponentInChildren<BrushSubStroke>() != null)
+				if (provider == null)
+				{
+					continue;
+				}
+
+				if (provider.SelfObject.TryGetComponent(out BrushSubStroke b))
 				{
 					continue;
 				}

--- a/Assets/Scripts/UI/Context/IContextProvider.cs
+++ b/Assets/Scripts/UI/Context/IContextProvider.cs
@@ -8,6 +8,7 @@ namespace CollabXR
 	/**
 	 * <summary>
 	 * Interface for spawning custom context menus when interacting with an object.
+	 * Should primarily be placed on the network object itself.
 	 * </summary>
 	 */
 	public interface IContextProvider

--- a/Assets/Scripts/UI/Context/IContextProvider.cs
+++ b/Assets/Scripts/UI/Context/IContextProvider.cs
@@ -17,5 +17,7 @@ namespace CollabXR
 		CollabContext AddTab(GameObject obj, CollabContextMenu menu);
 
 		GameObject GetContextPrefab() => null;
+
+		GameObject SelfObject => null;
 	}
 }


### PR DESCRIPTION
Fixes #22 

Caesium menu no longer should overlap with playback context menu.
Edits to context menus the just offset changes to avoid overlap issues in the menus.