### PR TITLE
reordered init functions in object preview

### DIFF
--- a/Assets/Scripts/Objects/CollabObjectPreview.cs
+++ b/Assets/Scripts/Objects/CollabObjectPreview.cs
@@ -44,9 +44,9 @@ namespace CollabXR.Objects
 		{
 			this.data = data;
 			EnableLoadingAnimation(true, data.availableOnThisPlatform);
-			LoadPrefab(data).Forget();
-
+			
 			SetupPreviewAsync().Forget();
+			LoadPrefab(data).Forget();
 		}
 
 		private async UniTaskVoid SetupPreviewAsync()


### PR DESCRIPTION
SetupPreviewAsync enables the loading box, and LoadPrefab disables the loading box only after the asset is loaded.

We used to call LoadPrefab first, then SetupPreviewAsync. For already loaded mods, LoadPrefab would disable the box, but then setuppreviewasync would enable it right after. So both the box and the asset shows up, which matches the reference image in the original issue description.

Swapping the two functions solves this for already loaded mods.

From manual testing in headset with the github actions build, it doesn't seem to impact other functionality.