### PR TITLE
Adding folder support for s3

### DIFF
--- a/Assets/Scripts/Modding/Datatypes/RepositoryMetadata.cs
+++ b/Assets/Scripts/Modding/Datatypes/RepositoryMetadata.cs
@@ -1,5 +1,6 @@
 using System;
-using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace CollabXR.ModLoader
 {
@@ -25,6 +26,24 @@ namespace CollabXR.ModLoader
 		public string accessKey;
 		public string secretKey;
 
-		public Guid[] Mods;
+		public string[] Mods;
+
+		/// <summary>
+		/// Stores the folder path in which the mod is stored, look up by mod guid
+		/// To get full path to mod, use folder path + mod guid
+		/// </summary>
+		[NonSerialized]
+		public Dictionary<Guid, string> rootFolderLookUp;
+
+		[OnDeserialized]
+		private void ConstructLookUpTable(StreamingContext context)
+		{
+			rootFolderLookUp = new();
+			foreach (var url in Mods)
+			{ 
+				int delim = url.LastIndexOf('/');
+				rootFolderLookUp.Add(new(url[(delim + 1)..]), url[..(delim + 1)]);
+			}
+		}
 	}
 }

--- a/Assets/Scripts/Modding/ModManager.cs
+++ b/Assets/Scripts/Modding/ModManager.cs
@@ -111,12 +111,13 @@ namespace CollabXR.ModLoader
 
 		private Uri GetAssetBundleURI(RepositoryMetadata repository, Guid modUuid)
 		{
-			return new Uri(new Uri(repository.BaseURL), $"{modUuid.ToString()}.{GetPlatformString()}");
+			var modUrl = repository.rootFolderLookUp[modUuid] + modUuid.ToString();
+			return new Uri(new Uri(repository.BaseURL), $"{modUrl}.{GetPlatformString()}");
 		}
 
-		private Uri GetAssetBundleMetaURI(RepositoryMetadata repository, Guid modUuid)
+		private Uri GetAssetBundleMetaURI(RepositoryMetadata repository, string modUrl)
 		{
-			return new Uri(new Uri(repository.BaseURL), $"{modUuid.ToString()}.meta.json");
+			return new Uri(new Uri(repository.BaseURL), $"{modUrl}.meta.json");
 		}
 
 		private static UnityWebRequest SignAWSWebRequest(UnityWebRequest request, RepositoryMetadata repository)
@@ -171,12 +172,16 @@ namespace CollabXR.ModLoader
 			return null;
 		}
 
-		internal async UniTask IndexMod(string repository, Guid modUuid)
+		internal async UniTask IndexMod(string repository, string modUrl)
 		{
 			await UniTask.SwitchToMainThread();
 
+			// parse mod guid from the url
+			Guid modUuid = new(modUrl[(modUrl.LastIndexOf("/") + 1)..]);
+
 			RepositoryMetadata repoData = RepositoryManager.Instance.loadedRepositories[repository];
-			UnityWebRequest repositoryRequest = GenerateAWSWebRequest(GetAssetBundleMetaURI(repoData, modUuid), repoData);
+			var assetBundleMetaURl = GetAssetBundleMetaURI(repoData, modUrl);
+			UnityWebRequest repositoryRequest = GenerateAWSWebRequest(assetBundleMetaURl, repoData);
 
 			try
 			{

--- a/Assets/Scripts/Modding/RepositoryManager.cs
+++ b/Assets/Scripts/Modding/RepositoryManager.cs
@@ -107,6 +107,8 @@ namespace CollabXR.ModLoader
 
 				await repositoryRequest.SendWebRequest();
 
+				Debug.Log($"{DEBUG_LOG_HEADER} Attempting to desearilize: {repositoryRequest.downloadHandler.text}");
+
 				RepositoryMetadata metadata = JsonConvert.DeserializeObject<RepositoryMetadata>(repositoryRequest.downloadHandler.text);
 
 				string query = new Uri(metadataUrl).Query;
@@ -120,9 +122,9 @@ namespace CollabXR.ModLoader
 
 				List<UniTask> indexModsTasks = new();
 
-				foreach (Guid modUuid in metadata.Mods)
+				foreach (string modUrl in metadata.Mods)
 				{
-					indexModsTasks.Add(ModManager.Instance.IndexMod(metadataUrl, modUuid));
+					indexModsTasks.Add(ModManager.Instance.IndexMod(metadataUrl, modUrl));
 				}
 
 				//await UniTask.SwitchToThreadPool();


### PR DESCRIPTION
Resolves #37.

Collab should now be able to index and load mods from within folders. Mod packager now has an option to specify a folder to upload into.
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/34eacab7-c3a2-487d-aef7-87ba5eebe1d1" />

Regarding "auto-placing packaged mods in their respective category folders", I believe only mod-prefabs have the Category field, and each uploaded mod can possibly contain several different mod-prefabs with different categories, so I'm not sure how we want to go about that.