### PR TITLE
bugfix: disable skybox enabled in passthrough

### DIFF
--- a/Assets/Scripts/Environment/EnvironmentScene.cs
+++ b/Assets/Scripts/Environment/EnvironmentScene.cs
@@ -21,6 +21,11 @@ namespace CollabXR.Environments
 			LoadNetworkObjects();
 		}
 
+		private void OnDestroy()
+		{
+			PassthroughManager.Instance.SetSkyboxOnInPassthrough(false);
+		}
+
 		private void LoadNetworkObjects()
 		{
 			if (environmentData.networkObjects.objects.Count > 0)


### PR DESCRIPTION
scenes like corinth and starfield have skyboxOnInPassthrough toggled true, and doesn't get toggled off when directly returning to the menu. Changed so all environments revert to the default behavior (toggled false) when being unloaded