### PR TITLE
devops: disable commit message in build notifications for now

### DIFF
--- a/.github/composite/upload/action.yml
+++ b/.github/composite/upload/action.yml
@@ -20,17 +20,14 @@ inputs:
   filename:
     description: "Name the uploaded file should have."
     required: true
-  webhook:
-    description: "Optional webhook secret"
-    default: null
-  platform-name:
-    description: "Name of platform for use in webhook"
-    default: "unspecified"
 
 outputs:
   file-size:
     description: "Resulting build size in kilobytes."
     value: ${{ steps.upload.outputs.FILE_SIZE }}
+  artifact-url:
+    description: "URL linking to the uploaded artifact."
+    value: ${{ steps.construct-artifact-url.outputs.ARTIFACT_URL }}
 
 runs:
   using: composite
@@ -84,12 +81,8 @@ runs:
           # Upload the file
           aws s3 cp ${FILENAME} $S3_PATH/$FOLDER_NAME/
 
-      - name: Notify
-        id: notify
-        if: ${{ inputs.webhook != null }}
+      - name: Construct Artifact URL
+        id: construct-artifact-url
         shell: bash
-        env: # Find a commit message or something to provide extra details
-          MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
-        # Notify developers that build finished
         run: |
-          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ inputs.platform-name }} ($FILE_SIZE KB): https://${{ inputs.bucket }}.s3.${{ inputs.region }}.amazonaws.com/$FOLDER_NAME/${{ inputs.filename }}\n> ${MESSAGE:q}\"}" ${{ inputs.webhook }}
+          echo "ARTIFACT_URL=https://${{ inputs.bucket }}.s3.${{ inputs.region }}.amazonaws.com/$FOLDER_NAME/${{ inputs.filename }}" >> $GITHUB_OUTPUT

--- a/.github/composite/upload/action.yml
+++ b/.github/composite/upload/action.yml
@@ -88,9 +88,8 @@ runs:
         id: notify
         if: ${{ inputs.webhook != null }}
         shell: bash
+        env: # Find a commit message or something to provide extra details
+          MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
+        # Notify developers that build finished
         run: |
-          # Find a commit message or something to provide extra details
-          MESSAGE="${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}"
-
-          # Notify developers that build finished
           curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ inputs.platform-name }} ($FILE_SIZE KB): https://${{ inputs.bucket }}.s3.${{ inputs.region }}.amazonaws.com/$FOLDER_NAME/${{ inputs.filename }}\n> ${MESSAGE:q}\"}" ${{ inputs.webhook }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,7 @@ jobs:
           read_nullsep message < <(jq -j '(tostring | gsub("\u0000"; ""), "\u0000")' <<'EOF'
           ${{ toJSON(github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha) }}
           EOF
+          ) || { echo "Error decoding metadata" >&2; exit 1; }
 
           echo "${message}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,4 +114,5 @@ jobs:
           MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
         # Notify developers that build finished
         run: |
+          echo ${MESSAGE:q}
           curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\n> ${MESSAGE:q}\"}" ${{ secrets.EC_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Notify
         id: notify
-        if: ${{ secrets.EC_WEBHOOK != null }}
+        # if: ${{ secrets.EC_WEBHOOK != null }}
         shell: bash
         env: # Find a commit message or something to provide extra details
           MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,12 @@ jobs:
             unity-build-profile: "Assets/Settings/BuildProfiles/WindowsDesktop.asset"
             output-binary: CollabXR.exe
             upload-name: CollabXR-Windows.zip
-          # - name: "quest3"
-          #   platform: [self-hosted, macOS, ARM64]
-          #   unity-hub-path: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
-          #   unity-build-profile: "Assets/Settings/BuildProfiles/QuestRelease.asset"
-          #   output-binary: CollabXR.apk
-          #   upload-name: CollabXR-Quest.apk
+          - name: "quest3"
+            platform: [self-hosted, macOS, ARM64]
+            unity-hub-path: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
+            unity-build-profile: "Assets/Settings/BuildProfiles/QuestRelease.asset"
+            output-binary: CollabXR.apk
+            upload-name: CollabXR-Quest.apk
           # - name: "macos"
           #   platform: [self-hosted, macOS, ARM64]
           #   unity-hub-path: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
@@ -71,40 +71,40 @@ jobs:
           persist-credentials: false
           set-safe-directory: false
 
-      # - name: Pull Git LFS
-      #   shell: bash
-      #   run: git lfs pull
+      - name: Pull Git LFS
+        shell: bash
+        run: git lfs pull
 
-      # - name: Setup CollabXR
-      #   id: setup
-      #   uses: ./.github/composite/setup
-      #   with:
-      #     unity-hub: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
-      #     unity-version: ${{ vars.UNITY_VERSION }}
-      #     keystore: ${{ secrets.COLLAB_KEYSTORE }}
-      #     token: ${{ secrets.ACCESS_TOKEN }}
-      #     photon-install-path: $GITHUB_WORKSPACE/Assets
+      - name: Setup CollabXR
+        id: setup
+        uses: ./.github/composite/setup
+        with:
+          unity-hub: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
+          unity-version: ${{ vars.UNITY_VERSION }}
+          keystore: ${{ secrets.COLLAB_KEYSTORE }}
+          token: ${{ secrets.ACCESS_TOKEN }}
+          photon-install-path: $GITHUB_WORKSPACE/Assets
 
-      # - name: Build CollabXR
-      #   id: build
-      #   uses: ./.github/composite/build
-      #   with:
-      #     unity: ${{ steps.setup.outputs.unity }}
-      #     build-profile: ${{ matrix.unity-build-profile }}
-      #     keystore-password: ${{ secrets.COLLAB_KEYSTORE_PASSWORD }}
-      #     output-name: ${{ matrix.output-binary }}
+      - name: Build CollabXR
+        id: build
+        uses: ./.github/composite/build
+        with:
+          unity: ${{ steps.setup.outputs.unity }}
+          build-profile: ${{ matrix.unity-build-profile }}
+          keystore-password: ${{ secrets.COLLAB_KEYSTORE_PASSWORD }}
+          output-name: ${{ matrix.output-binary }}
 
-      # # Configure AWS
-      # - name: Upload Artifact
-      #   id: upload
-      #   uses: ./.github/composite/upload
-      #   with:
-      #     access-key: ${{ vars.AWS_ACCESS_KEY }}
-      #     secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     region: ${{ secrets.S3_REGION }}
-      #     bucket: ${{ secrets.S3_BUCKET }}
-      #     filepath: ${{ steps.build.outputs.filepath }}
-      #     filename: ${{ matrix.upload-name }}
+      # Configure AWS
+      - name: Upload Artifact
+        id: upload
+        uses: ./.github/composite/upload
+        with:
+          access-key: ${{ vars.AWS_ACCESS_KEY }}
+          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          region: ${{ secrets.S3_REGION }}
+          bucket: ${{ secrets.S3_BUCKET }}
+          filepath: ${{ steps.build.outputs.filepath }}
+          filename: ${{ matrix.upload-name }}
 
       - name: Notify
         id: notify
@@ -112,7 +112,5 @@ jobs:
         shell: bash
         # env: # Find a commit message or something to provide extra details
           # MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
-        # Notify developers that build finished
-        # https://stackoverflow.com/a/77181733
         run: |
-          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\"}" ${{ secrets.EC_WEBHOOK }}
+          curl -s -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\"}" ${{ secrets.EC_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,9 +110,22 @@ jobs:
         id: notify
         # if: ${{ secrets.EC_WEBHOOK != null }}
         shell: bash
-        env: # Find a commit message or something to provide extra details
-          MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
-        # Notify developers that build finished #
+        # env: # Find a commit message or something to provide extra details
+          # MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
+        # Notify developers that build finished
+        # https://stackoverflow.com/a/77181733
         run: |
-          echo ${MESSAGE:q}
-          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\n> ${MESSAGE:q}\"}" ${{ secrets.EC_WEBHOOK }}
+          read_nullsep() {
+            local arg
+            for arg; do
+              IFS= read -r -d '' "$arg" || return
+            done
+          }
+
+          read_nullsep message < <(jq -j '(tostring | gsub("\u0000"; ""), "\u0000")' <<'EOF'
+          ${{ toJSON(github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha) }}
+          EOF
+
+          echo "${message}"
+
+          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\n> ${message}\"}" ${{ secrets.EC_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,18 +115,4 @@ jobs:
         # Notify developers that build finished
         # https://stackoverflow.com/a/77181733
         run: |
-          read_nullsep() {
-            local arg
-            for arg; do
-              IFS= read -r -d '' "$arg" || return
-            done
-          }
-
-          read_nullsep message < <(jq -j '(tostring | gsub("\u0000"; ""), "\u0000")' <<'EOF'
-          ${{ toJSON(github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha) }}
-          EOF
-          ) || { echo "Error decoding metadata" >&2; exit 1; }
-
-          echo "${message}"
-
-          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\n> ${message}\"}" ${{ secrets.EC_WEBHOOK }}
+          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\"}" ${{ secrets.EC_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,12 @@ jobs:
             unity-build-profile: "Assets/Settings/BuildProfiles/WindowsDesktop.asset"
             output-binary: CollabXR.exe
             upload-name: CollabXR-Windows.zip
-          - name: "quest3"
-            platform: [self-hosted, macOS, ARM64]
-            unity-hub-path: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
-            unity-build-profile: "Assets/Settings/BuildProfiles/QuestRelease.asset"
-            output-binary: CollabXR.apk
-            upload-name: CollabXR-Quest.apk
+          # - name: "quest3"
+          #   platform: [self-hosted, macOS, ARM64]
+          #   unity-hub-path: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
+          #   unity-build-profile: "Assets/Settings/BuildProfiles/QuestRelease.asset"
+          #   output-binary: CollabXR.apk
+          #   upload-name: CollabXR-Quest.apk
           # - name: "macos"
           #   platform: [self-hosted, macOS, ARM64]
           #   unity-hub-path: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         env: # Find a commit message or something to provide extra details
           MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
-        # Notify developers that build finished
+        # Notify developers that build finished #
         run: |
           echo ${MESSAGE:q}
           curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\n> ${MESSAGE:q}\"}" ${{ secrets.EC_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,39 +71,47 @@ jobs:
           persist-credentials: false
           set-safe-directory: false
 
-      - name: Pull Git LFS
+      # - name: Pull Git LFS
+      #   shell: bash
+      #   run: git lfs pull
+
+      # - name: Setup CollabXR
+      #   id: setup
+      #   uses: ./.github/composite/setup
+      #   with:
+      #     unity-hub: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
+      #     unity-version: ${{ vars.UNITY_VERSION }}
+      #     keystore: ${{ secrets.COLLAB_KEYSTORE }}
+      #     token: ${{ secrets.ACCESS_TOKEN }}
+      #     photon-install-path: $GITHUB_WORKSPACE/Assets
+
+      # - name: Build CollabXR
+      #   id: build
+      #   uses: ./.github/composite/build
+      #   with:
+      #     unity: ${{ steps.setup.outputs.unity }}
+      #     build-profile: ${{ matrix.unity-build-profile }}
+      #     keystore-password: ${{ secrets.COLLAB_KEYSTORE_PASSWORD }}
+      #     output-name: ${{ matrix.output-binary }}
+
+      # # Configure AWS
+      # - name: Upload Artifact
+      #   id: upload
+      #   uses: ./.github/composite/upload
+      #   with:
+      #     access-key: ${{ vars.AWS_ACCESS_KEY }}
+      #     secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     region: ${{ secrets.S3_REGION }}
+      #     bucket: ${{ secrets.S3_BUCKET }}
+      #     filepath: ${{ steps.build.outputs.filepath }}
+      #     filename: ${{ matrix.upload-name }}
+
+      - name: Notify
+        id: notify
+        if: ${{ secrets.EC_WEBHOOK != null }}
         shell: bash
-        run: git lfs pull
-
-      - name: Setup CollabXR
-        id: setup
-        uses: ./.github/composite/setup
-        with:
-          unity-hub: "/Applications/Unity\\ Hub.app/Contents/MacOS/Unity\\ Hub"
-          unity-version: ${{ vars.UNITY_VERSION }}
-          keystore: ${{ secrets.COLLAB_KEYSTORE }}
-          token: ${{ secrets.ACCESS_TOKEN }}
-          photon-install-path: $GITHUB_WORKSPACE/Assets
-
-      - name: Build CollabXR
-        id: build
-        uses: ./.github/composite/build
-        with:
-          unity: ${{ steps.setup.outputs.unity }}
-          build-profile: ${{ matrix.unity-build-profile }}
-          keystore-password: ${{ secrets.COLLAB_KEYSTORE_PASSWORD }}
-          output-name: ${{ matrix.output-binary }}
-
-      # Configure AWS
-      - name: Upload Artifact
-        id: upload
-        uses: ./.github/composite/upload
-        with:
-          access-key: ${{ vars.AWS_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          region: ${{ secrets.S3_REGION }}
-          bucket: ${{ secrets.S3_BUCKET }}
-          filepath: ${{ steps.build.outputs.filepath }}
-          filename: ${{ matrix.upload-name }}
-          webhook: ${{ secrets.EC_WEBHOOK }}
-          platform-name: ${{ matrix.name }}
+        env: # Find a commit message or something to provide extra details
+          MESSAGE: ${{ github.event.head_commit.message || github.event.workflow_run.head_commit.message || github.event.pull_request.title || github.sha }}
+        # Notify developers that build finished
+        run: |
+          curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"**${GITHUB_REF_NAME}** ${{ matrix.name }} (${{ steps.upload.outputs.file-size || '(no file)' }} KB): ${{ steps.upload.outputs.artifact-url || '(no url provided)' }}\n> ${MESSAGE:q}\"}" ${{ secrets.EC_WEBHOOK }}


### PR DESCRIPTION
Too easy to escape and execute arbitrarily in bash, and no good solution without adding something like a Python script which just creates another dependency for worker nodes.

Moves notifications out of the upload action and into their own step for easier testing/diagnosis.