### PR TITLE
ignoring currently overlapping brush stroke

### DIFF
--- a/Assets/Scripts/Tools/DrawingBrush.cs
+++ b/Assets/Scripts/Tools/DrawingBrush.cs
@@ -10,6 +10,7 @@ using NetworkPlayer = CollabXR.Networking.NetworkPlayer;
 namespace CollabXR.Tools
 {
 	[DefaultExecutionOrder(50)]
+	[RequireComponent(typeof(OverlapTracker))]
 	public class DrawingBrush : MonoBehaviour
 	{
 		[SerializeField]

--- a/Assets/Scripts/Tools/DrawingBrush.cs
+++ b/Assets/Scripts/Tools/DrawingBrush.cs
@@ -21,7 +21,14 @@ namespace CollabXR.Tools
 		[SerializeField]
 		private GameObject substrokePrefab;
 
+		private OverlapTracker overlapTracker;
+
 		public bool IsDrawing { get; set; }
+
+		private void Awake()
+		{
+			overlapTracker = GetComponent<OverlapTracker>();
+		}
 
 		public void SetIsDrawing(bool isDrawing)
 		{
@@ -85,6 +92,7 @@ namespace CollabXR.Tools
 			currentSubStroke = spawnedStroke.GetComponent<BrushSubStroke>();
 			currentSubStroke.SetParent(currentStrokeContainer);
 			currentSubStroke.Init(StrokeColor, baseStrokeWeight);
+			overlapTracker.ignoreObject = currentSubStroke.gameObject;
 
 			currentSubStroke.name += currentWholeStroke.Count;
 
@@ -174,6 +182,7 @@ namespace CollabXR.Tools
 			{
 				currentSubStroke.SetLastPoint(brushTipTransform.position, brushTipTransform.rotation);
 				currentSubStroke = null;
+				overlapTracker.ignoreObject = null;
 			}
 			currentWholeStroke.Clear();
 			currentStrokeContainer = null;

--- a/Assets/Scripts/Tools/OverlapTracker.cs
+++ b/Assets/Scripts/Tools/OverlapTracker.cs
@@ -19,6 +19,8 @@ namespace CollabXR.Objects
 		public UnityEvent<bool> isTouchingAnything;
 		public UnityEvent<bool> isNotTouchingAnything;
 
+		public GameObject ignoreObject;
+
 		private void Awake()
 		{
 			isTouchingAnything.AddListener((bool b) => isNotTouchingAnything.Invoke(!b));
@@ -41,7 +43,7 @@ namespace CollabXR.Objects
 
 		private void OnTriggerEnter(Collider other)
 		{
-			if (!overlappingObjects.Contains(other.gameObject))
+			if (!overlappingObjects.Contains(other.gameObject) && other.gameObject != ignoreObject)
 			{
 				overlappingObjects.Add(other.gameObject);
 				ApplyOverlappingObjectsChange();


### PR DESCRIPTION
* Fixed a bug where very distant brush strokes could get connected, often when testing on desktop. Resolves #150 